### PR TITLE
[FEAT] #23: 로그인 로직 추가

### DIFF
--- a/src/main/java/cc/team3/global/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/cc/team3/global/apiPayload/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // User 관련
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_401", "해당 유저를 찾을 수 없습니다."),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "USER_402", "비밀번호가 일치하지 않습니다."),
 
     // Character 관련
     CHARACTER_NOT_FOUND(HttpStatus.NOT_FOUND, "CHARACTER_401", "해당 캐릭터를 찾을 수 없습니다."),

--- a/src/main/java/cc/team3/user/controller/UserController.java
+++ b/src/main/java/cc/team3/user/controller/UserController.java
@@ -16,7 +16,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping
-    public ApiResponse<Long> saveUser(@RequestBody UserRequest.UserCreateRequestDTO request) {
-        return ApiResponse.onSuccess(userService.saveUser(request));
+    public ApiResponse<Long> loginOrRegister(@RequestBody UserRequest.UserLoginRequestDTO request) {
+        return ApiResponse.onSuccess(userService.loginOrRegister(request));
     }
 }

--- a/src/main/java/cc/team3/user/dto/UserRequest.java
+++ b/src/main/java/cc/team3/user/dto/UserRequest.java
@@ -1,8 +1,17 @@
 package cc.team3.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class UserRequest {
 
     public record UserCreateRequestDTO(String username, String password) {
 
+    }
+
+    public record UserLoginRequestDTO(
+        @JsonProperty("user_id") String username,
+        String password
+    ) {
+        
     }
 }

--- a/src/main/java/cc/team3/user/repository/UserRepository.java
+++ b/src/main/java/cc/team3/user/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package cc.team3.user.repository;
 
 import cc.team3.user.domain.User;
+
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/cc/team3/user/service/UserService.java
+++ b/src/main/java/cc/team3/user/service/UserService.java
@@ -1,9 +1,14 @@
 package cc.team3.user.service;
 
+import cc.team3.global.apiPayload.exception.GeneralException;
+import cc.team3.global.apiPayload.status.ErrorStatus;
 import cc.team3.user.domain.User;
 import cc.team3.user.dto.UserRequest;
 import cc.team3.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,5 +26,27 @@ public class UserService {
 
         userRepository.save(user);
         return user.getUserId();
+    }
+
+    @Transactional
+    public Long loginOrRegister(UserRequest.UserLoginRequestDTO request) {
+        Optional<User> optionalUser = userRepository.findByUsername(request.username());
+
+        if (optionalUser.isPresent()) {
+            User user = optionalUser.get();
+
+            if (!user.getPassword().equals(request.password())) {
+                throw new GeneralException(ErrorStatus.PASSWORD_MISMATCH);
+            }
+            return user.getUserId();
+        }
+        else {
+            UserRequest.UserCreateRequestDTO createRequest = new UserRequest.UserCreateRequestDTO(
+                request.username(),
+                request.password()
+            );
+
+            return saveUser(createRequest);
+        }
     }
 }


### PR DESCRIPTION
## Issue

- closes #23 


## Summary

- 로그인 기능을 구현했습니다.

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)
- `UserController`, `UserService`, `UserRepository`: `LoginOrRegister` 로직을 처리하기 위해 수정되었습니다.
- `UserRequest`: 로그인 요청을 처리하는 `UserLoginRequestDTO`가 추가되었습니다. `user_id` 요청 필드를 `username`으로 매핑하기 위해 `@JsonProperty`를 사용했습니다.
- `ErrorStatus`: 비밀번호 불일치 상황에 대한 `USER_402` 에러 코드가 추가되었습니다.
- `/api/users`에 POST 요청을 받아 로그인/회원가입을 수행합니다.
    - `-curl -X POST -H "Content-Type: application/json" -d '{"user_id": "아이디", "password": "비밀번호"}' localhost:8080/api/users`로 테스트해볼 수 있습니다.
- 입력한 user_id가 username에 존재하는지에 따라 아래와 같이 작동합니다.
- 이미 있는 회원의 경우
	- 비밀번호가 일치하는 경우
		- `{"isSuccess":true,"code":"COMMON200","message":"성공입니다.","result":1}`
		- `result`는 `user_id`에 해당합니다.
	- 비밀번호가 일치하지 않는 경우
		- `{"isSuccess":false,"code":"USER_402","message":"비밀번호가 일치하지 않습니다."}`
- 없는 회원의 경우
	- `{"isSuccess":true,"code":"COMMON200","message":"성공입니다.","result":3}`
	- 입력된 id, 비밀번호를 그대로 User 테이블에 등록하고 해당 `User`의 `user_id`를 반환합니다.
### 실행 결과
![image](https://github.com/user-attachments/assets/8bef87e7-5805-4b25-b957-93f64773e0a9)
![image](https://github.com/user-attachments/assets/16fb0099-77b4-4fba-8ce6-02ed1d2b445b)

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!