### PR TITLE
Feat/#25

### DIFF
--- a/src/main/java/cc/team3/character/controller/CharacterController.java
+++ b/src/main/java/cc/team3/character/controller/CharacterController.java
@@ -7,6 +7,9 @@ import cc.team3.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +27,11 @@ public class CharacterController {
     @PostMapping("/{characterId}/equipments")
     public ApiResponse<CharacterResponse.CharacterDetailsResponseDTO> createWeapon(@PathVariable("characterId") Long characterId, @RequestBody CharacterRequest.CreateEquipmentRequestDTO request) {
         return ApiResponse.onSuccess(characterService.createEquipment(characterId, request));
+    }
+
+    @Operation(summary = "전투 승패 기록", description = "승자와 패자 캐릭터 ID를 넣어주세요 !")
+    @PostMapping("/battle")
+    public ApiResponse<CharacterResponse.RecordBattleResponseDTO> recordBattle(@RequestBody CharacterRequest.RecordBattleRequestDTO request) {
+        return ApiResponse.onSuccess(characterService.recordBattle(request));
     }
 }

--- a/src/main/java/cc/team3/character/domain/Character.java
+++ b/src/main/java/cc/team3/character/domain/Character.java
@@ -80,4 +80,12 @@ public class Character {
     @ElementCollection
     @CollectionTable(name = "status_effects")
     private List<String> statusEffects;
+
+    public void incrementWins() {
+        this.wins++;
+    }
+    
+    public void incrementLosses() {
+        this.losses++;
+    }
 }

--- a/src/main/java/cc/team3/character/domain/Character.java
+++ b/src/main/java/cc/team3/character/domain/Character.java
@@ -64,6 +64,14 @@ public class Character {
     @Column(name = "accuracy")
     private Double accuracy;
 
+    @Column(name = "wins")
+    @Builder.Default
+    private Integer wins = 0;
+
+    @Column(name = "losses")
+    @Builder.Default
+    private Integer losses = 0;
+
     @ElementCollection
     @CollectionTable(name = "equipments")
     @Builder.Default

--- a/src/main/java/cc/team3/character/dto/CharacterRequest.java
+++ b/src/main/java/cc/team3/character/dto/CharacterRequest.java
@@ -6,4 +6,7 @@ public class CharacterRequest {
 
     public record CreateEquipmentRequestDTO(String equipmentType, String equipmentName, String description) {
     }
+
+    public record RecordBattleRequestDTO(Long winnerId, Long loserId) {
+    }
 }

--- a/src/main/java/cc/team3/character/dto/CharacterResponse.java
+++ b/src/main/java/cc/team3/character/dto/CharacterResponse.java
@@ -43,4 +43,7 @@ public class CharacterResponse {
             Double accuracy
     ) {
     }
+
+    public record RecordBattleResponseDTO(Long winnerId, Long loserId) {
+    }
 }

--- a/src/main/java/cc/team3/character/service/CharacterService.java
+++ b/src/main/java/cc/team3/character/service/CharacterService.java
@@ -57,4 +57,17 @@ public class CharacterService {
 
         return CharacterConverter.toCharacterDetailsResponseDTO(character, equipments);
     }
+
+    @Transactional
+    public CharacterResponse.RecordBattleResponseDTO recordBattle(CharacterRequest.RecordBattleRequestDTO request) {
+        Character winner = characterRepository.findById(request.winnerId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND));
+        Character loser = characterRepository.findById(request.loserId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND));
+
+        winner.incrementWins();
+        loser.incrementLosses();
+
+        return new CharacterResponse.RecordBattleResponseDTO(winner.getCharacterId(), loser.getCharacterId());
+    }
 }


### PR DESCRIPTION
## Issue

- closes #25 


## Summary

- 캐릭터 별 전투 승패 기록을 위한 api 및 로직을 구현했습니다.

## Describe your code

- `Character` 엔티티에 `wins`, `losses` 컬럼 추가 및 해당 값을 1씩 증가시키는 `incrementWins()`, `incrementLosses()` 메서드를 구현했습니다.
- `CharacterRequest`와 `CharacterResponse`에 각각 `RecordBattleRequestDTO`, `RecordBattleResponseDTO`를 추가했습니다.
- `CharacterService`에 전투 정보 저장을 위한 `recordBattle()` 메서드를 구현했습니다.
- `/api/characters/battle` 엔드포인트로 POST 요청을 받아 작동합니다. 이 api는 다음의 두 값을 json 형태로 받아야 합니다.
    - `winnerId`: 승자 캐릭터 id
    - `loserId`: 패자 캐릭터 id
- 승자의 `wins` 값을 +1, 패자의 `losses` 값을 +1만큼 증가시킵니다.
- 최종 응답으로 `winnerId`, `loserId` 값을 반환합니다.

## 실행 결과
![실행결과 요청 응답](https://github.com/user-attachments/assets/fb0d90e1-c668-435f-94cb-73a35945e086)
![실행결과 losses wins 값 변경](https://github.com/user-attachments/assets/b8d643e2-4405-4e58-99b5-edc1887a1433)


# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!