### PR TITLE
Feat/#37

### DIFF
--- a/src/main/java/cc/team3/character/domain/Character.java
+++ b/src/main/java/cc/team3/character/domain/Character.java
@@ -91,5 +91,13 @@ public class Character {
 
     public void addExp(Integer exp) {
         this.exp += exp;
+
+        // 레벨업: 1->2레벨은 100의 경험치, 2->3레벨은 150, 이후 50씩 증가
+        int requiredExp = 100 + (this.level - 1) * 50;
+        
+        while (this.exp >= requiredExp) {
+            this.exp -= requiredExp;
+            this.level++;
+        }
     }
 }

--- a/src/main/java/cc/team3/character/domain/Character.java
+++ b/src/main/java/cc/team3/character/domain/Character.java
@@ -88,4 +88,8 @@ public class Character {
     public void incrementLosses() {
         this.losses++;
     }
+
+    public void addExp(Integer exp) {
+        this.exp += exp;
+    }
 }

--- a/src/main/java/cc/team3/character/service/CharacterService.java
+++ b/src/main/java/cc/team3/character/service/CharacterService.java
@@ -69,7 +69,10 @@ public class CharacterService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND));
 
         winner.incrementWins();
+        winner.addExp(100);
+
         loser.incrementLosses();
+        loser.addExp(50);
 
         return new CharacterResponse.RecordBattleResponseDTO(winner.getCharacterId(), loser.getCharacterId());
     }


### PR DESCRIPTION
## Issue

- closes #37 


## Summary

- 전투 후 경험치 추가 및 경험치에 따른 레벨업 로직을 추가했습니다.

## Describe your code

- 주어진 만큼의 경험치를 추가하는 `addExp()` 메서드를 추가했습니다.
    - 경험치량에 따른 레벨업 로직을 추가했습니다.
        - 레벨당 100 + (현재 레벨 - 1) * 50의 경험치를 요구합니다.
- 전투 기록에서 `winner`에게 100의 경험치를, `loser`에게 50의 경험치를 제공합니다.

## 실행 결과
![Screenshot 2025-06-15 161213](https://github.com/user-attachments/assets/3e6b9b51-ccdf-4591-800c-9b8ab88bc72d)
1번 캐릭터는 5번 이겼으니 500의 경험치를, 2번 캐릭터는 5번 졌으니 250의 경험치를 갖습니다.
1번 캐릭터는 1->2레벨은 100, 2->3레벨은 150, 3->4레벨은 200의 경험치, 총 450의 경험치를 사용하여 4레벨, 경험치 50입니다.
2번 캐릭터는 총 250의 경험치를 사용하여 3레벨, 경험치 0을 달성합니다.

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!