### PR TITLE
[FIX] CharacterResponse의 ReadCharacterListDTO 내 loses를 losses로 변경

### DIFF
--- a/src/main/java/cc/team3/character/dto/CharacterResponse.java
+++ b/src/main/java/cc/team3/character/dto/CharacterResponse.java
@@ -57,7 +57,7 @@ public class CharacterResponse {
             Integer defense,
             Integer exp,
             Integer wins,
-            Integer loses
+            Integer losses
     ) {}
 
     public record DeleteCharacterResultDTO (


### PR DESCRIPTION
## Issue

- closes #41 


## Summary

- `loses`로 잘못 사용된 부분을 `losses`로 변경하였습니다.

## Describe your code

- CharacterResponse.java의 ReadCharacterListDTO 내 loses를 losses로 변경했습니다.
- 아래 사진처럼, 전역 검색 결과 프로젝트에 `loses`로 잘못 쓰인 다른 부분은 더이상 존재하지 않습니다.
![Screenshot 2025-06-15 180407](https://github.com/user-attachments/assets/196f216b-fcd1-4853-895f-e133a80fac75)

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!